### PR TITLE
Fix memory leak and missing null checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As mentioned before pgQuery4s uses libpg_query to get access to parse trees of S
 ```
 git submodule init
 git submodule update
-cd parser/src/main/native/libpg_query
+cd native/src/main/native/libpg_query
 make
 ```
 The pgQuery4s library itself can be then published locally.

--- a/core/src/main/scala/com/github/ivellien/pgquery/core/PgQueryException.scala
+++ b/core/src/main/scala/com/github/ivellien/pgquery/core/PgQueryException.scala
@@ -1,0 +1,4 @@
+package com.github.ivellien.pgquery.core
+
+// Define PgQueryException to extend Exception
+class PgQueryException(message: String, cause: Throwable = null) extends Exception(message, cause)

--- a/native/src/main/native/PgQueryWrapper.cpp
+++ b/native/src/main/native/PgQueryWrapper.cpp
@@ -5,16 +5,44 @@
 
 JNIEXPORT jstring JNICALL Java_com_github_ivellien_pgquery_native_PgQueryWrapper_pgQueryParse
   (JNIEnv *env, jobject obj, jstring string) {
-    const char* str = env->GetStringUTFChars(string, 0);
-    char *cap = (char *) malloc(strlen(str) + 1);
+    // Guard clause to check for null jstring argument
+    if (string == NULL) {
+        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "Input string cannot be null");
+        return NULL;
+    }
     
-    strcpy(cap, str);
-    PgQueryParseResult result = pg_query_parse(cap);
-    free(cap);
+    const char* cstr = env->GetStringUTFChars(string, 0);
 
-    char *res = (char *) malloc(strlen(result.parse_tree) + 1);
-    strcpy(res, result.parse_tree);
-    pg_query_free_parse_result(result);
+    // Check for NULL to ensure GetStringUTFChars succeeded
+    if (cstr == NULL) {
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"), "GetStringUTFChars failed in Java_com_github_ivellien_pgquery_native_PgQueryWrapper_pgQueryParse");
+        return NULL;
+    }
 
-    return env->NewStringUTF(res);
-  }
+    PgQueryParseResult parse_result = pg_query_parse(cstr);
+
+    // Release the string as it's no longer needed
+    env->ReleaseStringUTFChars(string, cstr);
+
+    // Check for parsing errors
+    if (parse_result.error) {
+        env->ThrowNew(env->FindClass("com/github/ivellien/pgquery/core/PgQueryException"), parse_result.error->message);
+        pg_query_free_parse_result(parse_result);
+        return NULL;
+    }
+
+    // Create a new Java string from the parse result
+    jstring result = env->NewStringUTF(parse_result.parse_tree);
+
+    // Check for NULL to ensure NewStringUTF succeeded
+    if (result == NULL) {
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"), "NewStringUTF failed in Java_com_github_ivellien_pgquery_native_PgQueryWrapper_pgQueryParse");
+        pg_query_free_parse_result(parse_result);
+        return NULL;
+    }
+
+    // Free the parse result as it's no longer needed
+    pg_query_free_parse_result(parse_result);
+
+    return result;
+}


### PR DESCRIPTION
Hi, some issues with this code:

```
JNIEXPORT jstring JNICALL Java_com_github_ivellien_pgquery_native_PgQueryWrapper_pgQueryParse
  (JNIEnv *env, jobject obj, jstring string) {
    const char* str = env->GetStringUTFChars(string, 0);
    char *cap = (char *) malloc(strlen(str) + 1);
    
    strcpy(cap, str);
    PgQueryParseResult result = pg_query_parse(cap);
    free(cap);

    char *res = (char *) malloc(strlen(result.parse_tree) + 1);
    strcpy(res, result.parse_tree);
    pg_query_free_parse_result(result);

    return env->NewStringUTF(res);
  }
```

* The `malloc`-ed string `res` is being leaked as `NewStringUTF` does not take ownership of it
* JNI expects `ReleaseStringUTFChars` to be called when you're done with the string returned by `GetStringUTFChars`, so that may be getting leaked as well
* The result of `GetStringUTFChars` can be used directly, as well as `result.parse_tree`; no need to `malloc` a separate buffer
* If `malloc` is called, the return value should be checked for `NULL`
* The `jstring string` should be checked for null